### PR TITLE
Fix codecov-action v5 breaking change: file -> files parameter

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
-          file: ./cobertura.xml
+          files: ./cobertura.xml
           plugin: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fixes the error: `Found 0 coverage files to report`.

`codecov/codecov-action@v5` renamed the `file` parameter (singular) to `files` (plural). With `disable_search: true` also set, the action was silently ignoring the path and finding nothing to upload.

https://claude.ai/code/session_01MA4PgNsyRNsQEoRDo2k35N