### PR TITLE
Reduce GitHub Actions usage

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,7 +3,18 @@
 on:
   push:
     branches: [main, master]
+    paths:
+      - 'R/**'
+      - 'tests/**'
+      - 'DESCRIPTION'
+      - 'NAMESPACE'
   pull_request:
+    branches: [main, master]
+    paths:
+      - 'R/**'
+      - 'tests/**'
+      - 'DESCRIPTION'
+      - 'NAMESPACE'
 
 name: R-CMD-check.yaml
 
@@ -21,9 +32,7 @@ jobs:
         config:
           - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,  r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,7 +3,6 @@
 on:
   push:
     branches: [main, master]
-  pull_request:
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -3,7 +3,16 @@
 on:
   push:
     branches: [main, master]
+    paths:
+      - 'R/**'
+      - 'tests/**'
+      - 'DESCRIPTION'
   pull_request:
+    branches: [main, master]
+    paths:
+      - 'R/**'
+      - 'tests/**'
+      - 'DESCRIPTION'
 
 name: test-coverage.yaml
 


### PR DESCRIPTION
Reduces the number and frequency of workflow runs:

- **R-CMD-check**: matrix trimmed from 5 → 3 platforms (drops `r: devel` and `r: oldrel-1`); path filters added so pushes/PRs only trigger when `R/`, `tests/`, `DESCRIPTION`, or `NAMESPACE` change; PR trigger restricted to `main`/`master`
- **test-coverage**: same path filters and PR branch restriction applied
- **pkgdown**: `pull_request` trigger removed — the docs site only needs rebuilding when changes land on `main` or a release is published

To restore the full 5-platform matrix before a CRAN submission, add back the `devel` and `oldrel-1` entries temporarily.

https://claude.ai/code/session_01MA4PgNsyRNsQEoRDo2k35N

---
_Generated by [Claude Code](https://claude.ai/code/session_01MA4PgNsyRNsQEoRDo2k35N)_